### PR TITLE
Replace vestigial references to Barlow and NotoSans with Arimo

### DIFF
--- a/src/components/addLayers/contextLayer.ts
+++ b/src/components/addLayers/contextLayer.ts
@@ -167,7 +167,7 @@ export async function makeContextLayerDataset(map: maplibregl.Map) {
 			//'text-field': ['coalesce', ['get', 'route_label']],
 			'text-field': ['get', 'route_label'],
 			//'text-variable-anchor': ['top', 'bottom', 'left', 'right'],
-			'text-font': ['literal', ['NotoSans-Regular']],
+			'text-font': ['literal', ['Arimo-Regular']],
 			'text-size': ['interpolate', ['linear'], ['zoom'], 5, 9, 9, 10, 11, 12, 13, 15],
 			'text-ignore-placement': false,
 			'text-allow-overlap': false,
@@ -251,9 +251,9 @@ export async function makeContextLayerDataset(map: maplibregl.Map) {
 			'text-font': [
 				'step',
 				['zoom'],
-				['literal', ['NotoSans-Regular']],
+				['literal', ['Arimo-Regular']],
 				13,
-				['literal', ['NotoSans-Medium']]
+				['literal', ['Arimo-Medium']]
 			]
 		},
 		paint: {
@@ -298,7 +298,7 @@ export async function makeContextLayerDataset(map: maplibregl.Map) {
 			//'icon-ignore-placement': false,
 			//'text-allow-overlap': true,
 			//'symbol-avoid-edges': false,
-			'text-font': ['NotoSans-Medium']
+			'text-font': ['Arimo-Medium']
 		},
 		paint: {
 			'text-color': darkMode ? '#ffffff' : '#1a1a1a',
@@ -345,9 +345,9 @@ export async function makeContextLayerDataset(map: maplibregl.Map) {
 			'text-font': [
 				'step',
 				['zoom'],
-				['literal', ['NotoSans-Regular']],
+				['literal', ['Arimo-Regular']],
 				6,
-				['literal', ['NotoSans-Medium']]
+				['literal', ['Arimo-Medium']]
 			]
 		},
 		paint: {
@@ -459,7 +459,7 @@ export async function makeContextLayerDots(map: maplibregl.Map) {
 			'text-variable-anchor': ['left', 'right'],
 			'text-radial-offset': 0.5,
 			'text-allow-overlap': false,
-			'text-font': ['NotoSans-SemiBold'],
+			'text-font': ['Arimo-SemiBold'],
 			'text-size': ['interpolate', ['linear'], ['zoom'], 9, 9, 11, 11, 13, 12, 15, 14],
 			'text-ignore-placement': ['step', ['zoom'], false, 10.5, true]
 		},

--- a/src/components/santa_tracker.ts
+++ b/src/components/santa_tracker.ts
@@ -286,7 +286,7 @@ function initializeSantaLayer(map: maplibregl.Map): void {
 					'icon-allow-overlap': true,
 					'icon-ignore-placement': true,
 					'text-field': '🎅 Santa',
-					'text-font': ['NotoSans-Bold'],
+					'text-font': ['Arimo-Bold'],
 					'text-size': 14,
 					'text-offset': [0, 1.5],
 					'text-anchor': 'top'

--- a/src/components/setup_load_map.ts
+++ b/src/components/setup_load_map.ts
@@ -279,7 +279,7 @@ function addStationLayers(
 					'text-size': ['interpolate', ['linear'], ['zoom'], 15, 5, 17, 8, 19, 9.5],
 					'text-radial-offset': 1,
 					'text-allow-overlap': true,
-					'text-font': ['NotoSans-Bold']
+					'text-font': ['Arimo-Bold']
 				},
 				paint: {
 					'text-color': darkMode ? '#bae6fd' : '#1d4ed8',

--- a/src/components/userradius.ts
+++ b/src/components/userradius.ts
@@ -37,7 +37,7 @@ export function addGeoRadius(map: maplibregl.Map) {
 			source: 'km_source',
 			layout: {
 				'text-field': ['get', 'label'],
-				'text-font': ['NotoSans-Bold'],
+				'text-font': ['Arimo-Bold'],
 				'symbol-placement': 'line',
 				'text-size': 8,
 				'symbol-spacing': 150,
@@ -77,7 +77,7 @@ export function addGeoRadius(map: maplibregl.Map) {
 			source: 'miles_source',
 			layout: {
 				'text-field': ['get', 'label'],
-				'text-font': ['NotoSans-Bold'],
+				'text-font': ['Arimo-Bold'],
 				'symbol-placement': 'line',
 				'text-size': 8,
 				'symbol-spacing': 150,

--- a/src/components/wildfireMap.ts
+++ b/src/components/wildfireMap.ts
@@ -25,7 +25,7 @@ async function make_fire_names(map: maplibregl.Map) {
 			'text-offset': [0, 1],
 			'text-anchor': 'top',
 			'text-size': ['interpolate', ['linear'], ['zoom'], 6, 6, 12, 14],
-			'text-font': ['NotoSans-Medium'],
+			'text-font': ['Arimo-Medium'],
 			'text-ignore-placement': true,
 			"icon-ignore-placement": true
 		},
@@ -63,7 +63,7 @@ async function make_fire_names(map: maplibregl.Map) {
 			'text-offset': [0, 1.5],
 			'text-anchor': 'top',
 			'text-size': ['interpolate', ['linear'], ['zoom'], 6, 6, 12, 14],
-			'text-font': ['NotoSans-Medium'],
+			'text-font': ['Arimo-Medium'],
 			'text-ignore-placement': true,
 			'icon-ignore-placement': true
 		},
@@ -519,7 +519,7 @@ export function makeFireMap(map: maplibregl.Map, chateaus_in_frame: Writable<str
 		layout: {
 			'text-field': ['concat', ['get', 'attr_IncidentName'], ' FIRE'],
 			'text-size': 10,
-			'text-font': ['NotoSans-Medium']
+			'text-font': ['Arimo-Medium']
 		},
 		minzoom: 5
 	});
@@ -535,7 +535,7 @@ export function makeFireMap(map: maplibregl.Map, chateaus_in_frame: Writable<str
 		layout: {
 			'text-field': ['concat', ['get', 'STATUS'], ''],
 			'text-size': ['interpolate', ['linear'], ['zoom'], 7, 8, 9, 13],
-			'text-font': ['NotoSans-Bold']
+			'text-font': ['Arimo-Bold']
 		},
 		minzoom: 6
 	});
@@ -557,7 +557,7 @@ export function makeFireMap(map: maplibregl.Map, chateaus_in_frame: Writable<str
 				' '
 			],
 			'text-size': ['interpolate', ['linear'], ['zoom'], 7, 8, 9, 12.5],
-			'text-font': ['NotoSans-Bold']
+			'text-font': ['Arimo-Bold']
 		},
 		minzoom: 6
 	});
@@ -578,7 +578,7 @@ export function makeFireMap(map: maplibregl.Map, chateaus_in_frame: Writable<str
 				12,
 				10
 			  ],
-			'text-font': ['NotoSans-Bold']
+			'text-font': ['Arimo-Bold']
 		},
 		paint: {
 			'text-color': darkMode ? '#ccaaaa' : '#cc0000'
@@ -602,7 +602,7 @@ export function makeFireMap(map: maplibregl.Map, chateaus_in_frame: Writable<str
 				12,
 				13
 			  ],
-			'text-font': ['NotoSans-Bold']
+			'text-font': ['Arimo-Bold']
 		},
 		paint: {
 			'text-color': darkMode ? '#ccaaaa' : '#cc0000'
@@ -627,7 +627,7 @@ export function makeFireMap(map: maplibregl.Map, chateaus_in_frame: Writable<str
 				' '
 			],
 			'text-size': ['interpolate', ['linear'], ['zoom'], 7, 9, 9, 13],
-			'text-font': ['NotoSans-Bold']
+			'text-font': ['Arimo-Bold']
 		},
 		minzoom: 6
 	});

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -21,10 +21,10 @@
 </div>
 
 <style>
-	@import url('https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
+	@import url('https://fonts.googleapis.com/css2?family=Arimo:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 
 	* {
-		font-family: 'Barlow', sans-serif;
+		font-family: 'Arimo', sans-serif;
 	}
 
 	.error-code {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -638,23 +638,23 @@
 					if (shortest_side >= 1600) {
 						mapglobal.setLayoutProperty(categoryvalues.labeldots, 'text-font', {
 							stops: [
-								[6, ['NotoSans-Medium']],
-								[12, ['NotoSans-SemiBold']]
+								[6, ['Arimo-Medium']],
+								[12, ['Arimo-SemiBold']]
 							]
 						});
 					} else {
 						mapglobal.setLayoutProperty(categoryvalues.labeldots, 'text-font', {
 							stops: [
-								[6, ['NotoSans-Regular']],
-								[14.5, ['NotoSans-Medium']]
+								[6, ['Arimo-Regular']],
+								[14.5, ['Arimo-Medium']]
 							]
 						});
 					}
 				} else {
 					mapglobal.setLayoutProperty(categoryvalues.labeldots, 'text-font', {
 						stops: [
-							[6, ['NotoSans-Medium']],
-							[11, ['NotoSans-SemiBold']]
+							[6, ['Arimo-Medium']],
+							[11, ['Arimo-SemiBold']]
 						]
 					});
 
@@ -1607,7 +1607,7 @@
 						'symbol-placement': 'line',
 						'text-size': 10,
 						'text-field': ['concat', ['number-format', ['get', 'ele'], {}], 'm'],
-						'text-font': ['NotoSans-Bold'],
+						'text-font': ['Arimo-Bold'],
 						'text-pitch-alignment': 'viewport'
 					},
 					paint: {

--- a/src/routes/chateausee/+page.svelte
+++ b/src/routes/chateausee/+page.svelte
@@ -109,7 +109,7 @@
 					'text-line-height': 1.2,
 					'text-letter-spacing': 0.01,
 					'text-max-width': 10,
-					'text-font': ['NotoSans-Medium'],
+					'text-font': ['Arimo-Medium'],
 					'text-offset': [0, 0]
 				},
 				paint: {

--- a/src/routes/shapestest/+page.svelte
+++ b/src/routes/shapestest/+page.svelte
@@ -113,7 +113,7 @@
 					'text-line-height': 1.2,
 					'text-letter-spacing': 0.01,
 					'text-max-width': 10,
-					'text-font': ['NotoSans-Medium'],
+					'text-font': ['Arimo-Medium'],
 					'text-offset': [0, 0]
 				},
 				paint: {

--- a/src/routes/unicode_map_test/+page.svelte
+++ b/src/routes/unicode_map_test/+page.svelte
@@ -41,7 +41,7 @@
 				layout: {
 					'text-size': 24,
 					'text-field': '𔐃𔐈𔐀𔐄𔙆f🐟f▦✺╬∅█☹',
-					'text-font': ['NotoSans-Regular']
+					'text-font': ['Arimo-Regular']
 				},
 				paint: {
 					'text-color': 'white',

--- a/static/dark-style-old-2025.json
+++ b/static/dark-style-old-2025.json
@@ -1839,7 +1839,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14,
@@ -1864,7 +1864,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 0, 10, 8, 14]
@@ -1896,7 +1896,7 @@
 					["get", "name"],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -1975,7 +1975,7 @@
 					["get", "name"],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -2072,7 +2072,7 @@
 				],
 				"text-anchor": "top",
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -2101,7 +2101,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0.9, 0],
 				"text-size": 12
@@ -2128,7 +2128,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13],
 				"text-pitch-alignment": "viewport"
@@ -2153,7 +2153,7 @@
 			"layout": {
 				"symbol-placement": "line",
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13],
 				"text-pitch-alignment": "viewport"
@@ -2186,7 +2186,7 @@
 					["concat", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Medium"],
+				"text-font": ["Arimo-Medium"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13],
 				"text-pitch-alignment": "viewport"
@@ -2217,7 +2217,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 8,
 				"visibility": "none"
@@ -2242,7 +2242,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 7, "line", 8, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -2268,7 +2268,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -2291,7 +2291,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-optional": true,
@@ -2325,7 +2325,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-letter-spacing": 0.1,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 8, 9, 12, 10],
@@ -2357,7 +2357,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 10, 11, 12]
 			},
@@ -2387,7 +2387,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 12, 11, 14]
 			},
@@ -2413,7 +2413,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 5, 10, 8, 14],
@@ -2445,7 +2445,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.1],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 11, 7, 13, 11, 18]
@@ -2471,7 +2471,7 @@
 				"icon-size": 0.5,
 				"text-anchor": "bottom",
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold"],
+				"text-font": ["Arimo-Bold"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.2],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 12, 7, 14, 11, 20]
@@ -2493,7 +2493,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], [">=", ["get", "rank"], 3]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold"],
+				"text-font": ["Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 3, 9, 7, 17]
 			},
@@ -2513,7 +2513,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 2]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold"],
+				"text-font": ["Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 2, 9, 5, 17]
 			},
@@ -2533,7 +2533,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 1]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Medium"],
+				"text-font": ["Arimo-Medium"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 1, 9, 4, 17]
 			},

--- a/static/dark-style-orm.json
+++ b/static/dark-style-orm.json
@@ -1885,7 +1885,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14
@@ -1909,7 +1909,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 0, 10, 8, 14]
@@ -1935,7 +1935,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14
@@ -1967,7 +1967,7 @@
 					["get", "name"],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -2046,7 +2046,7 @@
 					["get", "name"],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -2143,7 +2143,7 @@
 				],
 				"text-anchor": "top",
 				"text-field": ["get", "name"],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -2172,7 +2172,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0.9, 0],
 				"text-size": 12
@@ -2199,7 +2199,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
 			},
@@ -2228,7 +2228,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
 			},
@@ -2260,7 +2260,7 @@
 					["concat", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Medium"],
+				"text-font": ["Arimo-Medium"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
 			},
@@ -2290,7 +2290,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 8,
 				"visibility": "none"
@@ -2315,7 +2315,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 7, "line", 8, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -2341,7 +2341,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -2364,7 +2364,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-optional": true,
@@ -2398,7 +2398,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.1,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 8, 9, 12, 10],
@@ -2430,7 +2430,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 10, 11, 12]
 			},
@@ -2460,7 +2460,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 12, 11, 14]
 			},
@@ -2486,7 +2486,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 5, 10, 8, 14],
@@ -2518,7 +2518,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.1],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 11, 7, 13, 11, 18]
@@ -2544,7 +2544,7 @@
 				"icon-size": 0.5,
 				"text-anchor": "bottom",
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.2],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 12, 7, 14, 11, 20]
@@ -2566,7 +2566,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], [">=", ["get", "rank"], 3]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 3, 9, 7, 17]
 			},
@@ -2586,7 +2586,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 2]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 2, 9, 5, 17]
 			},
@@ -2606,7 +2606,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 1]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Medium"],
+				"text-font": ["Arimo-Medium"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 1, 9, 4, 17]
 			},

--- a/static/dark-style.json
+++ b/static/dark-style.json
@@ -2048,7 +2048,7 @@
 					["get", "name"],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans"],
+				"text-font": ["Arimo"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -2129,7 +2129,7 @@
 					["get", "name"],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans"],
+				"text-font": ["Arimo"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,

--- a/static/light-style-glyph-test.json
+++ b/static/light-style-glyph-test.json
@@ -1797,7 +1797,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14
@@ -1816,7 +1816,7 @@
 			"filter": ["match", ["geometry-type"], ["Point", "MultiPoint"], true, false],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 0, 10, 8, 14]
@@ -1842,7 +1842,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14
@@ -1895,7 +1895,7 @@
 				],
 				"text-anchor": "top",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12
@@ -1950,7 +1950,7 @@
 				],
 				"text-anchor": "top",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12
@@ -2004,7 +2004,7 @@
 				],
 				"text-anchor": "top",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12
@@ -2043,7 +2043,7 @@
 				"icon-size": 0.7,
 				"text-anchor": "left",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0.9, 0],
 				"text-size": 12
@@ -2070,7 +2070,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
 			},
@@ -2099,7 +2099,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 11, 14, 12]
 			},
@@ -2131,7 +2131,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
 			},
@@ -2161,7 +2161,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "visible"
@@ -2186,7 +2186,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 7, "line", 8, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -2211,7 +2211,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -2229,7 +2229,7 @@
 				"icon-size": 1,
 				"text-anchor": "top",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-optional": true,
@@ -2258,7 +2258,7 @@
 			],
 			"layout": {
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-letter-spacing": 0.1,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 8, 9, 12, 10],
@@ -2285,7 +2285,7 @@
 				"icon-size": 0.2,
 				"text-anchor": "bottom",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 10, 11, 12]
 			},
@@ -2310,7 +2310,7 @@
 				"icon-size": 0.2,
 				"text-anchor": "bottom",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 12, 11, 14]
 			},
@@ -2331,7 +2331,7 @@
 			"filter": ["==", ["get", "class"], "state"],
 			"layout": {
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Italic"],
+				"text-font": ["Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 5, 10, 8, 14],
@@ -2358,7 +2358,7 @@
 				"icon-size": 0.4,
 				"text-anchor": "bottom",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.1],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 11, 7, 13, 11, 18]
@@ -2384,7 +2384,7 @@
 				"icon-size": 0.5,
 				"text-anchor": "bottom",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Bold"],
+				"text-font": ["Arimo-Bold"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.2],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 12, 7, 14, 11, 20]
@@ -2406,7 +2406,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], [">=", ["get", "rank"], 3]],
 			"layout": {
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Bold"],
+				"text-font": ["Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 3, 9, 7, 17]
 			},
@@ -2426,7 +2426,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 2]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold"],
+				"text-font": ["Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 2, 9, 5, 17]
 			},
@@ -2446,7 +2446,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 1]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold"],
+				"text-font": ["Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 1, 9, 4, 17]
 			},

--- a/static/light-style-orm.json
+++ b/static/light-style-orm.json
@@ -1996,7 +1996,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14
@@ -2015,7 +2015,7 @@
 			"filter": ["match", ["geometry-type"], ["Point", "MultiPoint"], true, false],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 0, 10, 8, 14]
@@ -2041,7 +2041,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14
@@ -2094,7 +2094,7 @@
 				],
 				"text-anchor": "top",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12
@@ -2149,7 +2149,7 @@
 				],
 				"text-anchor": "top",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12
@@ -2203,7 +2203,7 @@
 				],
 				"text-anchor": "top",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12
@@ -2242,7 +2242,7 @@
 				"icon-size": 0.7,
 				"text-anchor": "left",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0.9, 0],
 				"text-size": 12
@@ -2269,7 +2269,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
 			},
@@ -2298,7 +2298,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 11, 14, 12]
 			},
@@ -2330,7 +2330,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
 			},
@@ -2360,7 +2360,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "visible"
@@ -2385,7 +2385,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 7, "line", 8, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -2410,7 +2410,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -2428,7 +2428,7 @@
 				"icon-size": 1,
 				"text-anchor": "top",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-optional": true,
@@ -2457,7 +2457,7 @@
 			],
 			"layout": {
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.1,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 8, 9, 12, 10],
@@ -2484,7 +2484,7 @@
 				"icon-size": 0.2,
 				"text-anchor": "bottom",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 10, 11, 12]
 			},
@@ -2509,7 +2509,7 @@
 				"icon-size": 0.2,
 				"text-anchor": "bottom",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 12, 11, 14]
 			},
@@ -2530,7 +2530,7 @@
 			"filter": ["==", ["get", "class"], "state"],
 			"layout": {
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 5, 10, 8, 14],
@@ -2557,7 +2557,7 @@
 				"icon-size": 0.4,
 				"text-anchor": "bottom",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.1],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 11, 7, 13, 11, 18]
@@ -2583,7 +2583,7 @@
 				"icon-size": 0.5,
 				"text-anchor": "bottom",
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.2],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 12, 7, 14, 11, 20]
@@ -2605,7 +2605,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], [">=", ["get", "rank"], 3]],
 			"layout": {
 				"text-field": ["coalesce", ["get", "name"], ["get", "name_en"]],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 3, 9, 7, 17]
 			},
@@ -2625,7 +2625,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 2]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 2, 9, 5, 17]
 			},
@@ -2645,7 +2645,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 1]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 1, 9, 4, 17]
 			},

--- a/static/lightstyle-bareboneslight.json
+++ b/static/lightstyle-bareboneslight.json
@@ -1363,7 +1363,7 @@
 			"filter": ["match", ["geometry-type"], ["Point", "MultiPoint"], true, false],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 0, 10, 8, 14]
@@ -1389,7 +1389,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14
@@ -1419,7 +1419,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 7, "line", 8, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"

--- a/static/orm_styles/standard-dark.json
+++ b/static/orm_styles/standard-dark.json
@@ -8445,7 +8445,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8489,7 +8489,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8533,7 +8533,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8576,7 +8576,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8619,7 +8619,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8653,7 +8653,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8700,7 +8700,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8743,7 +8743,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8792,7 +8792,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8839,7 +8839,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8883,7 +8883,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8930,7 +8930,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8973,7 +8973,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -9016,7 +9016,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -9076,7 +9076,7 @@
 				"icon-image": ["image", ["concat", "ormsdf:general/station-", ["get", "station_size"]]],
 				"icon-overlap": "always",
 				"text-field": "{label}",
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -9114,7 +9114,7 @@
 				"icon-image": ["image", ["concat", "ormsdf:general/station-", ["get", "station_size"]]],
 				"icon-overlap": "always",
 				"text-field": "{label}",
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -9349,7 +9349,7 @@
 				"symbol-z-order": "source",
 				"symbol-placement": "line",
 				"text-field": "{track_ref}",
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 10,
 				"text-padding": 10
 			}
@@ -9555,7 +9555,7 @@
 				"icon-image": ["image", ["concat", "ormsdf:general/station-", ["get", "station_size"]]],
 				"icon-overlap": "always",
 				"text-field": ["step", ["zoom"], ["get", "label"], 10, ["get", "name"]],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -9613,7 +9613,7 @@
 						["get", "name"]
 					]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-variable-anchor": ["center", "top", "bottom", "left", "right"],
 				"text-size": 11,
 				"text-padding": 10,

--- a/static/orm_styles/standard-light.json
+++ b/static/orm_styles/standard-light.json
@@ -8493,7 +8493,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8537,7 +8537,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8581,7 +8581,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8624,7 +8624,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8667,7 +8667,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8701,7 +8701,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8748,7 +8748,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8791,7 +8791,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8840,7 +8840,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8887,7 +8887,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8931,7 +8931,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -8978,7 +8978,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -9021,7 +9021,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -9064,7 +9064,7 @@
 					14,
 					["coalesce", ["get", "standard_label"], ""]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -9124,7 +9124,7 @@
 				"icon-image": ["image", ["concat", "ormsdf:general/station-", ["get", "station_size"]]],
 				"icon-overlap": "always",
 				"text-field": "{label}",
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -9162,7 +9162,7 @@
 				"icon-image": ["image", ["concat", "ormsdf:general/station-", ["get", "station_size"]]],
 				"icon-overlap": "always",
 				"text-field": "{label}",
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -9397,7 +9397,7 @@
 				"symbol-z-order": "source",
 				"symbol-placement": "line",
 				"text-field": "{track_ref}",
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 10,
 				"text-padding": 10
 			}
@@ -9603,7 +9603,7 @@
 				"icon-image": ["image", ["concat", "ormsdf:general/station-", ["get", "station_size"]]],
 				"icon-overlap": "always",
 				"text-field": ["step", ["zoom"], ["get", "label"], 10, ["get", "name"]],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-size": 11,
 				"text-padding": 10,
 				"text-max-width": 5,
@@ -9661,7 +9661,7 @@
 						["get", "name"]
 					]
 				],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-variable-anchor": ["center", "top", "bottom", "left", "right"],
 				"text-size": 11,
 				"text-padding": 10,

--- a/static/pitch-black.json
+++ b/static/pitch-black.json
@@ -1561,7 +1561,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14,
@@ -1586,7 +1586,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 0, 10, 8, 14]
@@ -1612,7 +1612,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14
@@ -1644,7 +1644,7 @@
 					["get", "name"],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -1723,7 +1723,7 @@
 					["get", "name"],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -1820,7 +1820,7 @@
 				],
 				"text-anchor": "top",
 				"text-field": ["get", "name"],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -1849,7 +1849,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0.9, 0],
 				"text-size": 12
@@ -1876,7 +1876,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13],
 				"text-pitch-alignment": "viewport"
@@ -1901,7 +1901,7 @@
 			"layout": {
 				"symbol-placement": "line",
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13],
 				"text-pitch-alignment": "viewport"
@@ -1934,7 +1934,7 @@
 					["concat", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Medium"],
+				"text-font": ["Arimo-Medium"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13],
 				"text-pitch-alignment": "viewport"
@@ -1965,7 +1965,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 8,
 				"visibility": "none"
@@ -1990,7 +1990,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 7, "line", 8, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -2016,7 +2016,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -2039,7 +2039,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-optional": true,
@@ -2073,7 +2073,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.1,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 8, 9, 12, 10],
@@ -2105,7 +2105,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 10, 11, 12]
 			},
@@ -2135,7 +2135,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 12, 11, 14]
 			},
@@ -2161,7 +2161,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 5, 10, 8, 14],
@@ -2193,7 +2193,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.1],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 11, 7, 13, 11, 18]
@@ -2219,7 +2219,7 @@
 				"icon-size": 0.5,
 				"text-anchor": "bottom",
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.2],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 12, 7, 14, 11, 20]
@@ -2241,7 +2241,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], [">=", ["get", "rank"], 3]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 3, 9, 7, 17]
 			},
@@ -2261,7 +2261,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 2]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 2, 9, 5, 17]
 			},
@@ -2281,7 +2281,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 1]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Medium"],
+				"text-font": ["Arimo-Medium"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 1, 9, 4, 17]
 			},

--- a/static/sat-style.json
+++ b/static/sat-style.json
@@ -1429,7 +1429,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14
@@ -1453,7 +1453,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 0, 10, 8, 14]
@@ -1479,7 +1479,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 5,
 				"text-size": 14
@@ -1511,7 +1511,7 @@
 					["get", "name"],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -1590,7 +1590,7 @@
 					["get", "name"],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -1687,7 +1687,7 @@
 				],
 				"text-anchor": "top",
 				"text-field": ["get", "name"],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-size": 12,
@@ -1716,7 +1716,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-max-width": 9,
 				"text-offset": [0.9, 0],
 				"text-size": 12
@@ -1743,7 +1743,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
 			},
@@ -1772,7 +1772,7 @@
 					["concat", ["get", "name:latin"], " ", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
 			},
@@ -1804,7 +1804,7 @@
 					["concat", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Medium"],
+				"text-font": ["Arimo-Medium"],
 				"text-rotation-alignment": "map",
 				"text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 14, 13]
 			},
@@ -1834,7 +1834,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 8,
 				"visibility": "none"
@@ -1859,7 +1859,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 7, "line", 8, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -1885,7 +1885,7 @@
 				"symbol-placement": ["step", ["zoom"], "point", 11, "line"],
 				"symbol-spacing": 200,
 				"text-field": ["to-string", ["get", "ref"]],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-rotation-alignment": "viewport",
 				"text-size": 10,
 				"visibility": "none"
@@ -1908,7 +1908,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 9,
 				"text-offset": [0, 0.6],
 				"text-optional": true,
@@ -1942,7 +1942,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.1,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 8, 9, 12, 10],
@@ -1974,7 +1974,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 10, 11, 12]
 			},
@@ -2004,7 +2004,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 7, 12, 11, 14]
 			},
@@ -2030,7 +2030,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["Barlow-Italic", "NotoSans-Italic"],
+				"text-font": ["Arimo-Italic", "Arimo-Italic"],
 				"text-letter-spacing": 0.2,
 				"text-max-width": 9,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 5, 10, 8, 14],
@@ -2062,7 +2062,7 @@
 					["concat", ["get", "name:latin"], "\n", ["get", "name:nonlatin"]],
 					["coalesce", ["get", "name"], ["get", "name_en"]]
 				],
-				"text-font": ["NotoSans-Regular"],
+				"text-font": ["Arimo-Regular"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.1],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 11, 7, 13, 11, 18]
@@ -2088,7 +2088,7 @@
 				"icon-size": 0.5,
 				"text-anchor": "bottom",
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 8,
 				"text-offset": [0, -0.2],
 				"text-size": ["interpolate", ["exponential", 1.2], ["zoom"], 4, 12, 7, 14, 11, 20]
@@ -2110,7 +2110,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], [">=", ["get", "rank"], 3]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 3, 9, 7, 17]
 			},
@@ -2130,7 +2130,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 2]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Bold", "NotoSans-Bold"],
+				"text-font": ["Arimo-Bold", "Arimo-Bold"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 2, 9, 5, 17]
 			},
@@ -2150,7 +2150,7 @@
 			"filter": ["all", ["==", ["get", "class"], "country"], ["==", ["get", "rank"], 1]],
 			"layout": {
 				"text-field": ["get", "name"],
-				"text-font": ["NotoSans-Medium"],
+				"text-font": ["Arimo-Medium"],
 				"text-max-width": 6.25,
 				"text-size": ["interpolate", ["linear"], ["zoom"], 1, 9, 4, 17]
 			},


### PR DESCRIPTION
While I'm not sure if Arimo is the right choice in the long run, we've decided to go with Arimo for now.

This PR makes of the random UI and map elements that are still using Barlow or Noto Sans use Arimo instead, so that the interface is more consistent.